### PR TITLE
feat/18 能力値を入れた際に、決定されるステータスが表示されるようにした

### DIFF
--- a/character-manager/src/components/creations/CharacterSkills.jsx
+++ b/character-manager/src/components/creations/CharacterSkills.jsx
@@ -7,6 +7,7 @@ import { Typography } from "@mui/material";
 export default function CharacterSkills(props) {
     useEffect(() => props.setCharacterBasicSkills(props.characterBasicSkills), [props]);
     useEffect(() => props.setCharacterBattleSkills(props.characterBattleSkills), [props]);
+    useEffect(() => props.setCharacterSkillsTableStatus(props.characterSkillsTableStatus), [props]);
 
     return (
         <Grid item xs container direction="column">
@@ -14,7 +15,9 @@ export default function CharacterSkills(props) {
             <Grid item container sx={{ mb: 2 }}>
                 <BasicSkillsEditableTable 
                     characterSkills = {props.characterBasicSkills}
-                    setCharacterSkills = {props.setCharacterBasicSkills}/>
+                    setCharacterSkills = {props.setCharacterBasicSkills}
+                    characterSkillsTableStatus = {props.characterSkillsTableStatus}
+                    setCharacterSkillsTableStatus = {props.setCharacterSkillsTableStatus}/>
             </Grid>
             <Typography variant="h4" style={{ textalign: 'left' }} sx={{ mt: 2, mb: 2 }}>戦闘技能</Typography>
             <Grid item container sx={{ mb: 2 }}>

--- a/character-manager/src/components/creations/CharacterStatus.jsx
+++ b/character-manager/src/components/creations/CharacterStatus.jsx
@@ -6,53 +6,34 @@ import StatusEditableTable from "../modules/EditableTable/StatusEditableTable";
 
 export default function CharacterStatus(props) {
   useEffect(() => props.setCharacterStatus(props.characterStatus),[props]);
+  useEffect(() => props.setCharacterSkillsTableStatus(props.characterSkillsTableStatus),[props]);
   
   return (
     <Grid item xs container direction="column">
       <Grid item container>
         <StatusEditableTable 
           characterStatus = {props.characterStatus}
-          setCharacterStatus = {props.setCharacterStatus}/>
+          setCharacterStatus = {props.setCharacterStatus}
+          characterSkillsTableStatus = {props.characterSkillsTableStatus}
+          setCharacterSkillsTableStatus = {props.setCharacterSkillsTableStatus}/>
       </Grid>
       <Grid item container>
-        <Grid item xs={4} sx={{ pr: 1 }}>
-          <FormControl sx={{ m: 1, width: 1, backgroundColor: 'white' }} variant="outlined"
-          onChange={(event)=>props.setCharacterStatus({...props.characterStatus, idea:event.target.value})}>
-            <TextField id="idea" label="アイデア" variant="outlined" />
+        <Grid item xs={3} sx={{ pr: 1 }}>
+          <FormControl sx={{ m: 1, width: 1, backgroundColor: 'white' }} variant="outlined">
+            <TextField id="outlined-read-only-input" label="初期正気度" value={props.characterStatus.init_san} InputProps={{readOnly: true}}/>
           </FormControl>
         </Grid>
-        <Grid item xs={4} sx={{ pl: 1 }}>
-          <FormControl sx={{ m: 1, width: 1, backgroundColor: 'white' }} variant="outlined"
-          onChange={(event)=>props.setCharacterStatus({...props.characterStatus, knowledge:event.target.value})}>
-            <TextField id="knowledge" label="知識" variant="outlined" />
+        <Grid item xs={3} sx={{ pl: 1 }}>
+          <FormControl sx={{ m: 1, width: 1, backgroundColor: 'white' }} variant="outlined">
+            <TextField id="outlined-read-only-input" label="不定の狂気" value={props.characterStatus.init_san*4/5} InputProps={{readOnly: true}}/>
           </FormControl>
         </Grid>
-        <Grid item xs={4} sx={{ pl: 1 }}>
-          <FormControl sx={{ m: 1, width: 1, backgroundColor: 'white' }} variant="outlined"
-          onChange={(event)=>props.setCharacterStatus({...props.characterStatus, damage_bonus:event.target.value})}>
-            <TextField id="damageBonus" label="ダメージ・ボーナス" variant="outlined" />
+        <Grid item xs={3} sx={{ pl: 1 }}>
+          <FormControl sx={{ m: 1, width: 1, backgroundColor: 'white' }} variant="outlined">
+            <TextField id="outlined-read-only-input" label="ダメージ・ボーナス" value={props.characterStatus.damage_bonus} InputProps={{readOnly: true}}/>
           </FormControl>
         </Grid>
-      </Grid>
-      <Grid item container>
-        <Grid item xs={4} sx={{ pr: 1 }}>
-          <FormControl sx={{ m: 1, width: 1, backgroundColor: 'white' }} variant="outlined"
-          onChange={(event)=>props.setCharacterStatus({...props.characterStatus, init_san:event.target.value})}>
-            <TextField id="initSan" label="初期正気度" variant="outlined" />
-          </FormControl>
-        </Grid>
-        <Grid item xs={4} sx={{ pl: 1 }}>
-          <FormControl sx={{ m: 1, width: 1, backgroundColor: 'white' }} variant="outlined"
-          onChange={(event)=>props.setCharacterStatus({...props.characterStatus, current_san:event.target.value})}>
-            <TextField id="currentSan" label="正気度" variant="outlined" />
-          </FormControl>
-        </Grid>
-        <Grid item xs={4} sx={{ pl: 1 }}>
-          <FormControl sx={{ m: 1, width: 1, backgroundColor: 'white' }} variant="outlined"
-          onChange={(event)=>props.setCharacterStatus({...props.characterStatus, luck:event.target.value})}>
-            <TextField id="luck" label="幸運" variant="outlined" />
-          </FormControl>
-        </Grid>
+
       </Grid>
     </Grid>
   );

--- a/character-manager/src/components/modules/ConstantTableFields.jsx
+++ b/character-manager/src/components/modules/ConstantTableFields.jsx
@@ -2,6 +2,7 @@ export const STATUS_FIELDS = [
     {
       id: 1,
       name: "能力値",
+      SAN: 0,
       STR: 0,
       CON: 0,
       POW: 0,
@@ -11,11 +12,15 @@ export const STATUS_FIELDS = [
       INT: 0,
       EDU: 0,
       HP: 0,
-      MP: 0
+      MP: 0,
+      IDEA: 0,
+      LUCK: 0,
+      KNOWLEDGE: 0,
     },
     {
       id: 2,
       name: "増加分",
+      SAN: 0,
       STR: 0,
       CON: 0,
       POW: 0,
@@ -25,11 +30,15 @@ export const STATUS_FIELDS = [
       INT: 0,
       EDU: 0,
       HP: 0,
-      MP: 0
+      MP: 0,
+      IDEA: 0,
+      LUCK: 0,
+      KNOWLEDGE: 0,
     },
     {
       id: 3,
       name: "一時的",
+      SAN: 0,
       STR: 0,
       CON: 0,
       POW: 0,
@@ -39,11 +48,15 @@ export const STATUS_FIELDS = [
       INT: 0,
       EDU: 0,
       HP: 0,
-      MP: 0
+      MP: 0,
+      IDEA: 0,
+      LUCK: 0,
+      KNOWLEDGE: 0,
     },
     {
       id: 4,
       name: "現在値",
+      SAN: 0,
       STR: 0,
       CON: 0,
       POW: 0,
@@ -53,7 +66,10 @@ export const STATUS_FIELDS = [
       INT: 0,
       EDU: 0,
       HP: 0,
-      MP: 0
+      MP: 0,
+      IDEA: 0,
+      LUCK: 0,
+      KNOWLEDGE: 0,
     },
   ];
 

--- a/character-manager/src/components/modules/EditableTable/BasicSkillsEditableTable.jsx
+++ b/character-manager/src/components/modules/EditableTable/BasicSkillsEditableTable.jsx
@@ -1,21 +1,24 @@
-import React, {useEffect, useState} from "react";
+import React, {useEffect} from "react";
 import { DataGrid } from '@mui/x-data-grid';
-import * as fields from "../ConstantTableFields";
 import _ from 'lodash';
 
 export default function BasicSkillsEditableTable(props) {
     useEffect(() => props.setCharacterSkills(props.characterSkills), [props]);
-    const [status, setStatus] = useState(rows);
+    useEffect(() => props.setCharacterSkillsTableStatus(props.characterSkillsTableStatus), [props]);
 
     const changeCell = (v) => {
-        let newValue = _.cloneDeep(status);
-        let idx = status.findIndex(d => d.id === v.id);
-        let sum = status[idx].init_point + status[idx].job_point + status[idx].concern_point + status[idx].grow + status[idx].other
-                    - status[idx][v.field] + v.value;
+        let newValue = _.cloneDeep(props.characterSkillsTableStatus);
+        let idx = props.characterSkillsTableStatus.findIndex(d => d.id === v.id);
+        let sum = props.characterSkillsTableStatus[idx].init_point 
+                    + props.characterSkillsTableStatus[idx].job_point 
+                    + props.characterSkillsTableStatus[idx].concern_point 
+                    + props.characterSkillsTableStatus[idx].grow 
+                    + props.characterSkillsTableStatus[idx].other
+                    - props.characterSkillsTableStatus[idx][v.field] + v.value;
         newValue[idx][v.field] = v.value;
         newValue[idx].summary = sum;
         newValue[idx].init_flag = false;
-        setStatus(newValue);
+        props.setCharacterSkillsTableStatus(newValue);
         // テーブルの値を親コンポーネントに返す関数
         setTableValue(newValue)
     }
@@ -34,7 +37,7 @@ export default function BasicSkillsEditableTable(props) {
         <div style={{ width: '100%' }}>
             <DataGrid
                 autoHeight
-                rows={status}
+                rows={props.characterSkillsTableStatus}
                 columns={columns}
                 disableColumnMenu={true}
                 hideFooter
@@ -56,5 +59,3 @@ const columns = [
     { field: 'other', headerName: 'その他', type: 'number', flex: 2, editable: true, sortable: false, headerAlign: 'center' },
     { field: 'summary', headerName: '合計', type: 'number', flex: 2, editable: false, sortable: false, headerAlign: 'center' }
 ];
-
-const rows = fields.BASIC_SKILLS_FIELDS;

--- a/character-manager/src/components/modules/EditableTable/StatusEditableTable.jsx
+++ b/character-manager/src/components/modules/EditableTable/StatusEditableTable.jsx
@@ -27,7 +27,7 @@ export default function CharacterStatus(props) {
         }
         if(v.field === "DEX"){
             let newSkillsValue = _.cloneDeep(props.characterSkillsTableStatus);
-            newSkillsValue[6].init_point = sum*2;
+            newSkillsValue[6].init_point = sum*2;   //定義の6番目の要素に「回避」があるので、その初期値を変更
             props.setCharacterSkillsTableStatus(newSkillsValue);
         }
         if(v.field === "INT"){
@@ -36,7 +36,7 @@ export default function CharacterStatus(props) {
         if(v.field === "EDU"){
             newValue[0]["KNOWLEDGE"] = sum*5;
             let newSkillsValue = _.cloneDeep(props.characterSkillsTableStatus);
-            newSkillsValue[47].init_point = sum*5;
+            newSkillsValue[47].init_point = sum*5;  //定義の47番目の要素に「母国語」があるので、その初期値を変更
             props.setCharacterSkillsTableStatus(newSkillsValue);
         }
         if(v.field === "CON" || v.field === "SIZ"){

--- a/character-manager/src/components/modules/EditableTable/StatusEditableTable.jsx
+++ b/character-manager/src/components/modules/EditableTable/StatusEditableTable.jsx
@@ -5,31 +5,83 @@ import _ from 'lodash';
 
 export default function CharacterStatus(props) {
     useEffect(() => props.setCharacterStatus(props.characterStatus),[props]);
+    useEffect(() => props.setCharacterSkillsTableStatus(props.characterSkillsTableStatus),[props]);
     const [status, setStatus] = useState(rows);
 
     const changeCell = (v) => {
         let newValue = _.cloneDeep(status);
-        let idx = status.findIndex(d => d.id === v.id);
+        let idx = status.findIndex(d => d.id === v.id);        
+        if (idx === 0 && (v.field === "SAN" || v.field === "HP" || v.field === "MP" || v.field === "IDEA" || v.field === "LUCK" || v.field === "KNOWLEDGE")){
+            v.value = status[0][v.field]
+        }
         let sum = status[0][v.field] + status[1][v.field] + status[2][v.field] - status[idx][v.field] + v.value;
+        let damage_bonus = "";
+
         newValue[idx][v.field] = v.value;
         newValue[3][v.field] = sum;
+        
+        if(v.field === "POW"){
+            newValue[0]["SAN"] = sum*5;
+            newValue[0]["LUCK"] = sum*5;
+            newValue[0]["MP"] = sum;
+        }
+        if(v.field === "DEX"){
+            let newSkillsValue = _.cloneDeep(props.characterSkillsTableStatus);
+            newSkillsValue[6].init_point = sum*2;
+            props.setCharacterSkillsTableStatus(newSkillsValue);
+        }
+        if(v.field === "INT"){
+            newValue[0]["IDEA"] = sum*5;
+        }        
+        if(v.field === "EDU"){
+            newValue[0]["KNOWLEDGE"] = sum*5;
+            let newSkillsValue = _.cloneDeep(props.characterSkillsTableStatus);
+            newSkillsValue[47].init_point = sum*5;
+            props.setCharacterSkillsTableStatus(newSkillsValue);
+        }
+        if(v.field === "CON" || v.field === "SIZ"){
+            newValue[0]["HP"] = newValue[3]["CON"] + newValue[3]["SIZ"];
+        }
+
         setStatus(newValue);
-        setTableValue(sum,v.field);
+        if(v.field === "STR" || v.field === "SIZ"){ damage_bonus = calcDamageBonus(newValue[3]["STR"], newValue[3]["SIZ"]); }
+        setTableValue(sum, v.field, damage_bonus, newValue[0]["HP"]);
     }
 
-    const setTableValue = (sum,field) => {
-        field=="STR" ? props.setCharacterStatus({...props.characterStatus, str:sum})
-        : field =="CON" ? props.setCharacterStatus({...props.characterStatus, con:sum})
-        : field =="POW" ? props.setCharacterStatus({...props.characterStatus, pow:sum, init_san:sum*5,luck:sum*5})
-        : field =="DEX" ? props.setCharacterStatus({...props.characterStatus, dex:sum})
-        : field =="APP" ? props.setCharacterStatus({...props.characterStatus, app:sum})
-        : field =="SIZ" ? props.setCharacterStatus({...props.characterStatus, size:sum})
-        : field =="INT" ? props.setCharacterStatus({...props.characterStatus, int:sum, idea:sum*5})
-        : field =="EDU" ? props.setCharacterStatus({...props.characterStatus, edu:sum, knowledge:sum*5})
-        : field =="HP" ? props.setCharacterStatus({...props.characterStatus, hp:sum})
-        : field =="MP" ? props.setCharacterStatus({...props.characterStatus, mp:sum})
-        : field =="db" ? props.setCharacterStatus({...props.characterStatus, damage_bonus:sum})
+    const setTableValue = (sum,field,damage_bonus,hp) => {
+                
+        field === "STR" ? props.setCharacterStatus({...props.characterStatus, str:sum, damage_bonus: damage_bonus}) 
+        : field === "CON" ? props.setCharacterStatus({...props.characterStatus, con:sum, hp:hp})
+        : field === "POW" ? props.setCharacterStatus({...props.characterStatus, pow:sum, init_san:sum*5,luck:sum*5,mp:sum})
+        : field === "DEX" ? props.setCharacterStatus({...props.characterStatus, dex:sum})
+        : field === "APP" ? props.setCharacterStatus({...props.characterStatus, app:sum})
+        : field === "SIZ" ? props.setCharacterStatus({...props.characterStatus, size:sum, damage_bonus: damage_bonus, hp:hp})
+        : field === "INT" ? props.setCharacterStatus({...props.characterStatus, int:sum, idea:sum*5})
+        : field === "EDU" ? props.setCharacterStatus({...props.characterStatus, edu:sum, knowledge:sum*5})
+        : field === "SAN" ? props.setCharacterStatus({...props.characterStatus, current_san:sum})
         : console.log(sum,field)
+    }
+
+    const calcDamageBonus = (str, siz) =>{
+        let damage_bonus ="";
+        str+siz < 2 ? damage_bonus = "エラー"
+        :(2 <= str+siz && str+siz < 13) ? damage_bonus = "-1D6"
+        :(13 <= str+siz && str+siz < 17) ? damage_bonus = "-1D4"
+        :(17 <= str+siz && str+siz < 25) ? damage_bonus = "0"
+        :(25 <= str+siz && str+siz < 33) ? damage_bonus = "+1D4"
+        :(33 <= str+siz && str+siz < 41) ? damage_bonus = "+1D6"
+        :(41 <= str+siz && str+siz < 57) ? damage_bonus = "+2D6"
+        :(57 <= str+siz && str+siz < 73) ? damage_bonus = "+3D6"
+        :(73 <= str+siz && str+siz < 89) ? damage_bonus = "+4D6"
+        :(89 <= str+siz && str+siz < 105) ? damage_bonus = "+5D6"
+        :(105 <= str+siz && str+siz < 121) ? damage_bonus = "+6D6"
+        :(121 <= str+siz && str+siz < 137) ? damage_bonus = "+7D6"
+        :(137 <= str+siz && str+siz < 153) ? damage_bonus = "+8D6"
+        :(153 <= str+siz && str+siz < 169) ? damage_bonus = "+9D6"
+        :(169 <= str+siz && str+siz < 185) ? damage_bonus = "+10D6"
+        :(185 <= str+siz) ? damage_bonus = "エラー"
+        : console.log(str+siz)
+        return damage_bonus;
     }
     return (
         <div style={{ width: '100%' }}>
@@ -38,7 +90,7 @@ export default function CharacterStatus(props) {
                 rows={status}
                 columns={columns}
                 disableColumnMenu={true}
-                isCellEditable={(params) => params.row.name !== "現在値" || (params.row.name !=="能力値" && params.HP !== 0)}
+                isCellEditable={(params) => (params.row.name === "能力値") || params.row.name === "増加分"|| params.row.name === "一時的" }
                 hideFooter
                 showCellRightBorder
                 showColumnRightBorder
@@ -50,6 +102,7 @@ export default function CharacterStatus(props) {
 
 const columns = [
     { field: 'name', headerName: '', flex: 1, editable: false, sortable: false, align: 'center' },
+    { field: 'SAN', headerName: 'SAN', type: 'number', flex: 1, editable: true, sortable: false, headerAlign: 'center' },
     { field: 'STR', headerName: 'STR', type: 'number', flex: 1, editable: true, sortable: false, headerAlign: 'center' },
     { field: 'CON', headerName: 'CON', type: 'number', flex: 1, editable: true, sortable: false, headerAlign: 'center' },
     { field: 'POW', headerName: 'POW', type: 'number', flex: 1, editable: true, sortable: false, headerAlign: 'center' },
@@ -60,6 +113,9 @@ const columns = [
     { field: 'EDU', headerName: 'EDU', type: 'number', flex: 1, editable: true, sortable: false, headerAlign: 'center' },
     { field: 'HP', headerName: 'HP', type: 'number', flex: 1, editable: true, sortable: false, headerAlign: 'center' },
     { field: 'MP', headerName: 'MP', type: 'number', flex: 1, editable: true, sortable: false, headerAlign: 'center' },
-];
+    { field: 'IDEA', headerName: 'アイデア', type: 'number', flex: 1, editable: true, sortable: false, headerAlign: 'center' },
+    { field: 'LUCK', headerName: '幸運', type: 'number', flex: 1, editable: true, sortable: false, headerAlign: 'center' },
+    { field: 'KNOWLEDGE', headerName: '知識', type: 'number', flex: 1, editable: true, sortable: false, headerAlign: 'center' },
+]
 
 const rows = fields.STATUS_FIELDS;

--- a/character-manager/src/components/pages/CharacterCreate.jsx
+++ b/character-manager/src/components/pages/CharacterCreate.jsx
@@ -15,6 +15,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { Button, Typography } from "@mui/material";
 import ScrollToTop from "../modules/ScrollToTop";
 import { useNavigate } from "react-router-dom";
+import * as fields from "../modules/ConstantTableFields";
 
 const Accordion = styled((props) => (
     <MuiAccordion  {...props} />
@@ -155,12 +156,13 @@ const CharacterCreate = () => {
     const [basicCharaInfo, setbasicCharaInfo]=useState(basicCharaInfoInit);
     const [additionalInfo, setAdditionalInfo]=useState(additionalInfoInit);
     const [characterStatus, setCharacterStatus]=useState(characterStatusInit);
-    const [characterSkills, setCharacterSkills]=useState(characterSkillsInit);
     const [characterBasicSkills, setCharacterBasicSkills]=useState(characterBasicSkillsInit);
     const [characterBattleSkills, setCharacterBattleSkills]=useState(characterBattleSkillsInit);
     const [characterBelongings, setCharacterBelongings]=useState(characterBelongingsInit);
     const [characterMemo, setCharacterMemo]=useState(characterMemoInit);
     const [characterOthers, setCharacterOthers]=useState(characterOthersInit);
+    
+    const [characterSkillsTableStatus, setCharacterSkillsTableStatus]=useState(fields.BASIC_SKILLS_FIELDS);
 
     const accordionInfo = [
         {
@@ -179,7 +181,9 @@ const CharacterCreate = () => {
             Name: "能力値",
             Contents: <CharacterStatus 
                 characterStatus = {characterStatus}
-                setCharacterStatus = {setCharacterStatus}/>
+                setCharacterStatus = {setCharacterStatus}
+                characterSkillsTableStatus = {characterSkillsTableStatus}
+                setCharacterSkillsTableStatus = {setCharacterSkillsTableStatus}/>
         },
         {
             Name: "技能値",
@@ -187,7 +191,9 @@ const CharacterCreate = () => {
                 characterBasicSkills = {characterBasicSkills}
                 setCharacterBasicSkills = {setCharacterBasicSkills}
                 characterBattleSkills = {characterBattleSkills}
-                setCharacterBattleSkills = {setCharacterBattleSkills}/>
+                setCharacterBattleSkills = {setCharacterBattleSkills}
+                characterSkillsTableStatus = {characterSkillsTableStatus}
+                setCharacterSkillsTableStatus = {setCharacterSkillsTableStatus}/>
         },
         {
             Name: "所持品",


### PR DESCRIPTION
アイデア、知識、正気度、幸運を上の表の項目に入れ、自動で入力されるようにする
正気度は一番左、アイデア、知識、幸運は一番右
初期正気度、不定の狂気、ダメージ・ボーナスを下の欄に表示させる
これらの欄は変更できない

回避の初期値=DEX×2
母国語=EDU×5
で初期値が入力されるようにする