### PR TITLE
バックエンドとの疎通バグの修正

### DIFF
--- a/character-manager/src/components/modules/EditableTable/BasicSkillsEditableTable.jsx
+++ b/character-manager/src/components/modules/EditableTable/BasicSkillsEditableTable.jsx
@@ -15,7 +15,7 @@ export default function BasicSkillsEditableTable(props) {
         newValue[idx][v.field] = v.value;
         newValue[idx].summary = sum;
         newValue[idx].init_flag = false;
-        newValue[idx].skill_type = "basic";
+        newValue[idx].skill_type = 1; //basic:1, battle:2, custom:3
         props.setCharacterSkillsTableStatus(newValue);
         setStatus(newValue);
         // テーブルの値を親コンポーネントに返す関数

--- a/character-manager/src/components/modules/EditableTable/StatusEditableTable.jsx
+++ b/character-manager/src/components/modules/EditableTable/StatusEditableTable.jsx
@@ -22,6 +22,7 @@ export default function CharacterStatus(props) {
         
         if(v.field === "POW"){
             newValue[0]["SAN"] = sum*5;
+            newValue[3]["SAN"] = sum*5;
             newValue[0]["LUCK"] = sum*5;
             newValue[0]["MP"] = sum;
         }
@@ -52,7 +53,7 @@ export default function CharacterStatus(props) {
                 
         field === "STR" ? props.setCharacterStatus({...props.characterStatus, str:sum, damage_bonus: damage_bonus}) 
         : field === "CON" ? props.setCharacterStatus({...props.characterStatus, con:sum, hp:hp})
-        : field === "POW" ? props.setCharacterStatus({...props.characterStatus, pow:sum, init_san:sum*5,luck:sum*5,mp:sum})
+        : field === "POW" ? props.setCharacterStatus({...props.characterStatus, pow:sum, init_san:sum*5,luck:sum*5,mp:sum,current_san:sum*5})
         : field === "DEX" ? props.setCharacterStatus({...props.characterStatus, dex:sum})
         : field === "APP" ? props.setCharacterStatus({...props.characterStatus, app:sum})
         : field === "SIZ" ? props.setCharacterStatus({...props.characterStatus, size:sum, damage_bonus: damage_bonus, hp:hp})

--- a/character-manager/src/const/characterInit.json
+++ b/character-manager/src/const/characterInit.json
@@ -1,5 +1,5 @@
 {
-    "Readme":"多分、これいらないけど、何かに使えるかもしれないので、残してる",
+    "Readme":"type: basic→1, battle→2, custom→3",
     "basic_info":
     {
         "character_name" : "",
@@ -23,7 +23,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -35,7 +35,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -47,7 +47,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -59,7 +59,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -71,7 +71,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -83,7 +83,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -95,7 +95,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -107,7 +107,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -119,7 +119,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -131,7 +131,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -143,7 +143,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -155,7 +155,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -167,7 +167,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -179,7 +179,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -191,7 +191,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -203,7 +203,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -215,7 +215,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -227,7 +227,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -239,7 +239,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -251,7 +251,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -263,7 +263,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -275,7 +275,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -287,7 +287,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -299,7 +299,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -311,7 +311,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -323,7 +323,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -335,7 +335,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -347,7 +347,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -359,7 +359,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -371,7 +371,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -383,7 +383,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -395,7 +395,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -407,7 +407,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -419,7 +419,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -431,7 +431,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -443,7 +443,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -455,7 +455,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -467,7 +467,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -479,7 +479,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -491,7 +491,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -503,7 +503,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -515,7 +515,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -527,7 +527,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -539,7 +539,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -551,7 +551,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -563,7 +563,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -575,7 +575,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -587,7 +587,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -599,7 +599,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -611,7 +611,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -623,7 +623,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -635,7 +635,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Basic",
+            "type":1,
             "init_flag":1
         },
         {
@@ -647,7 +647,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Battle",
+            "type":2,
             "init_flag":1
         },
         {
@@ -659,7 +659,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Battle",
+            "type":2,
             "init_flag":1
         },
         {
@@ -671,7 +671,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Battle",
+            "type":2,
             "init_flag":1
         },
         {
@@ -683,7 +683,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Battle",
+            "type":2,
             "init_flag":1
         },
         {
@@ -695,7 +695,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Battle",
+            "type":2,
             "init_flag":1
         },
         {
@@ -707,7 +707,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Battle",
+            "type":2,
             "init_flag":1
         },
         {
@@ -719,7 +719,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Battle",
+            "type":2,
             "init_flag":1
         },
         {
@@ -731,7 +731,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Battle",
+            "type":2,
             "init_flag":1
         },
         {
@@ -743,7 +743,7 @@
             "concern_point":0,
             "grow":0,
             "other":0,
-            "type":"Battle",
+            "type":2,
             "init_flag":1
         }
     ],


### PR DESCRIPTION
## 概要
キャラクター作成時、バックエンドとの疎通バグを修正

## 修正箇所
1. skill_typeがintで受け入れていたため、下記仕様とし、intで渡すように修正
    - basic:1, battle:2, custom:3
2. POWを入力しただけでは現在値のＳＡＮが登録・送信されなかったため修正
    - 細かなことを言うと、SANの増減を計算した後にSANの初期値を変更されると齟齬が発生しそうだが、いったん無視する→issueだけ作る